### PR TITLE
mapping of sgpas with semesterids

### DIFF
--- a/scrapper/brute.js
+++ b/scrapper/brute.js
@@ -128,25 +128,40 @@ function parseHTML(htmlContent){
   const rollNo = $('td:contains("RollNo")').next().next().text().trim() || 'N/A';
   const name = $('td:contains("Institute Code")').next().next().text().replace(/[0-9()]/g, '').trim().replace(/[\n\r\t]/g, '') || 'N/A';
   const branch = $('td:contains("Branch Code")').next().next().text().replace(/[0-9()]/g, '').trim() || 'N/A';
-  const sgpa = $('td:contains("SGPA")').next().next().text().trim() || 'N/A';
   const fullName = $('td:contains("Name")').next().next().text().replace(/[0-9()]/g, '').trim().replace(/[\n\r\t]/g, '') || 'N/A';
-
   const names = fullName.split(/\s\s+/).map(name => name.trim()).filter(name => name);
   const firstName = names[9];
-  let semesters = 'N/A';
-  
-  
-  if(sgpa != 'N/A'){
-    const sgpas = sgpa.match(/\d+\.\d+/g);
-    semesters = sgpas.reduce((acc, sgpa, index) => {
-      acc[`sem${index + 1}`] = parseFloat(sgpa);
-      return acc;
-    }, {});
-  }
+ 
+  let semesters = {};
+
+  $('[id*="forlblSemesterId"]').each((i, elem) => {
+    let semester = $(elem)
+      .closest("tr")
+      .find('[id*="lblSemesterId"]')
+      .text()
+      .replace(/[A-Za-z]/g, "")
+      .trim();
+
+    let sgpa =
+      $(elem)
+        .closest("tr")
+        .next()
+        .next()
+        .next()
+        .find('[id*="lblSGPA"]')
+        .text()
+        .trim() || "N/A";
+
+    let sgpaValue = parseFloat(sgpa);
+
+    if (sgpa !== "N/A" && sgpaValue !== 0) {
+      semesters[`sem${semester}`] = sgpaValue;
+    }
+  });
 
   
 
-  if (rollNo == 'N/A' || name == 'N/A' || branch == 'N/A' || fullName == 'N/A' || !sgpa) {
+  if (rollNo == 'N/A' || name == 'N/A' || branch == 'N/A' || fullName == 'N/A') {
     return null;
   }
 


### PR DESCRIPTION
## Changes Made

- Updated the SGPA extraction logic to handle semester-wise data


## Key Improvements


Semester-wise SGPA:
   - Now extracts SGPA for each semester individually
   - Stores SGPA values in a `semesters` object with keys like `sem1`, `sem2`, etc.
   - Ignores semesters with SGPA of 0 or "N/A"


## Benefits

- More detailed SGPA information, allowing for better analysis of student performance across semesters


## Testing

Please test this function with various HTML inputs, including:
- Records with multiple semesters
- Records with missing or incomplete data
- Results with multiple backlogs.

(Although I had tested it :) )

![Screenshot from 2024-08-09 20-16-21](https://github.com/user-attachments/assets/cf57724b-d7b0-4a1e-9219-e720469bdb88)